### PR TITLE
Remove necessidade de criar os hashes em outro serviço

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm install
 ## Creating `dist/index.html`
 
 ```console
-$ poetry run python create_html.py <PATH TO PDF FILE>
+$ poetry run python create_html.py [<PATH TO PDF FILE>]
 ```
 
 ## Creating `dist/app.js`

--- a/create_html.py
+++ b/create_html.py
@@ -9,15 +9,18 @@ from tika import parser
 
 @click.command()
 @click.argument(
-    "pdf_path", type=click.Path(exists=False, dir_okay=False, readable=True)
+    "pdf_path", type=click.Path(exists=False, dir_okay=False, readable=True), required=False
 )
-def create_html(pdf_path):
+def create_html(pdf_path=None):
     """Parse the PDF with sensitive information generating the index.html with
     hashes of the names of the people listed in the document. The index.html
-     comes with the basic Elm app structure."""
-    click.echo(f"Parsing to {pdf_path}.")
-    parsed = parser.from_file(pdf_path)
-    lines = [line for line in parsed["content"].split("\n") if line.strip()]
+    comes with the basic Elm app structure."""
+    if pdf_path is None:
+        lines = []
+    else:
+        click.echo(f"Parsing to {pdf_path}.")
+        parsed = parser.from_file(pdf_path)
+        lines = [line for line in parsed["content"].split("\n") if line.strip()]
 
     hashes = []
     click.echo("Filtering and hashing names.")
@@ -30,7 +33,7 @@ def create_html(pdf_path):
 
     template = Path() / "index.template.html"
     index = Path() / "dist" / "index.html"
-    contents = template.read_text().replace("/* insert hashes here */", dumps(hashes))
+    contents = template.read_text().replace("[null]", dumps(hashes))
     index.write_text(contents)
     click.echo(f"Saved to {index}.")
 

--- a/index.template.html
+++ b/index.template.html
@@ -12,38 +12,38 @@
   </head>
   <body>
     <div class="container">
-
       <h1>Checar se fui exposto no dossiê de Anti-fascistas</h1>
-      <p>No dia 3 de junho de 2020 ficamos sabendo que um dossiê com possíveis anti-fascistas foi exposto na internet.</p>
-      <p>Para checar se seu nome está no dossiê sem correr o risco de expor seus dados use esse serviço.</p>
+      <p>No dia 3 de junho de 2020, ficamos sabendo que um dossiê com possíveis anti-fascistas foi exposto na internet.</p>
+      <p>A partir do documento PDF obtido, construímos uma lista de <em>hashes</em> a partir dos nomes mencionados,
+      de forma que apenas os <em>hashes</em> estão disponibilizados nessa página. Embora o nome completo seja solicitado
+      a seguir, o mesmo não é trafegado na internet, muito menos exposto a outros serviços.</p>
 
-      <h2>Antes de começar<br><strong>Não</strong> digite seus dados pessoais em sites que você não conhece.</h2>
-      <p>Esse site foi construído para funcionar sem necessitar de dados pessoais, apenas de parte do hash dos mesmos.</p>
-
-      <h2>1. Gere um <em>hash</em> com o seu nome completo</h2>
-      <p>Utilizamos <code>sha512</code> para não expor seu nome. Você pode usar o <a href="https://duckduckgo.com">Duck Duck Go</a> para gerar um hash com o seu nome. É só colocar SHA-512 e o seu nome no campo de busca.</p>
-      <p>Aqui um exemplo com o nome <a href="https://duckduckgo.com/?q=sha-512+Jo%C3%A3o+da+Silva&atb=v181-3_j&ia=answer">"João da Silva".</a></p>
-      <p>Vale a pena gerar com variações de maiúscula e minúscula, com ou sem acento, etc.</p>
-
-      <h2>2. Informe os 100 primeiros caracteres do seu <em>hash</em></h2>
-      <p>É só colar, a gente corta os caracteres que vierem a mais:</p>
+      <h2>Informe o seu nome completo</h2>
+      <p>A partir do seu nome completo é criado um <em>hash</em> (com o algoritmo SHA-512) para verificarmos se o mesmo se encontra na base de <em>hashes</em>.</p>
+      <p>Seu nome não será exposto ou enviado através da internet. Os <em>hashes</em> para análise já se encontram nesta página.</p>
       <div id="pwned-antifas"></div>
 
-      <h2>Por que <em>hashes</em></h2>
+      <h2>Por que <em>hashes</em>?</h2>
       <p>Esse site não contém os dados presentes no dossiê, somente parte dos hashes dos nomes.</p>
-      <p>Isso garante que a publicação desse site não expõe as pessoas a um risco ainda maior.</p>
-      <p>O algoritmo usado foi o <code>sha512</code>./</p>
-      <p>Para verificar se os seus dados estão presentes, insira no campo os oito primeiros caracteres do hash do seu nome completo.</p>
-      <p>Essa é a única forma de garantir que seus dados não estão sendo compartilhados de forma imprópria.</p>
+      <p>Isso garante que a publicação desse site não exponha as pessoas a um risco ainda maior.</p>
+      <p>O algoritmo usado foi o <a href="https://pt.wikipedia.org/wiki/SHA-2"><code>SHA-512</code></a>, o qual garante que os nomes sejam ofuscados e sejam carregados nessa página de forma anônima.</p>
+      <p>Essa é a única forma de garantir que seus dados não estão sendo compartilhados de forma imprópria, mas, sim, de forma segura e anônima.</p>
 
       <h2>O código é aberto?</h2>
-      <p><a href="https://github.com/cuducos/pwned-antifas">Sim</a>, mas não expomos o PDF do dossiê para não dar mais visibilidade e expor ainda mais as pessoas.</p>
-
+      <p><a href="https://github.com/cuducos/pwned-antifas">Sim</a>! Embora o PDF do dossiê não seja exposto, para não dar mais visibilidade e expor ainda mais as pessoas mencionadas,
+      você pode conferir como essa ferramenta foi criada e auditar (ou modificar) <a href="https://github.com/cuducos/pwned-antifas">a solução proposta</a>.</p>
     </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-sha512/0.8.0/sha512.min.js" integrity="sha256-vmT+cGA/37TLJdcbn/L89qtu3RA/LEozREmaqY+pg4E=" crossorigin="anonymous"></script>
     <script>
       var app = Elm.Main.init({
         node: document.getElementById('pwned-antifas'),
-        flags: /* insert hashes here */
+        flags: [null]
+      });
+
+      app.ports.requestHash.subscribe(function(message) {
+        console.log("received: " + message);
+        console.log("sending: " + sha512(message));
+        app.ports.receiveHash.send(sha512(message));
       });
     </script>
   </body>

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "url": "https://github.com/cuducos/pwned-antifas/issues"
   },
   "homepage": "https://github.com/cuducos/pwned-antifas#readme",
-  "dependencies": {},
   "devDependencies": {
     "elm": "^0.19.1-3",
-    "elm-live": "^4.0.1"
+    "elm-live": "^4.0.1",
+    "js-sha512": "^0.8.0"
   }
 }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2,15 +2,15 @@ module Main exposing (main)
 
 import Browser
 import Model exposing (Model)
-import Update exposing (Msg, update)
+import Update exposing (Msg, update, subscriptions)
 import View exposing (view)
-
 
 init : List String -> ( Model, Cmd Msg )
 init hashes =
     ( { found = False
       , hashes = hashes
       , hash = ""
+      , fullName = ""
       }
     , Cmd.none
     )
@@ -22,5 +22,5 @@ main =
         { init = init
         , view = view
         , update = update
-        , subscriptions = \_ -> Sub.none
+        , subscriptions = subscriptions
         }

--- a/src/Model.elm
+++ b/src/Model.elm
@@ -2,9 +2,9 @@ module Model exposing (Model)
 
 import Dict exposing (Dict)
 
-
 type alias Model =
     { found : Bool
     , hashes : List String
     , hash : String
+    , fullName : String
     }

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -1,0 +1,4 @@
+port module Ports exposing (requestHash, receiveHash)
+
+port requestHash : String -> Cmd msg
+port receiveHash : (String -> msg) -> Sub msg

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -1,12 +1,12 @@
-module Update exposing (Msg(..), update)
+module Update exposing (Msg(..), update, subscriptions)
 
 import Dict
 import Model exposing (Model)
-
+import Ports exposing (requestHash, receiveHash)
 
 type Msg
-    = UpdateValue String
-
+    = RequestHash String
+    | ReceiveHash String
 
 isListed : Model -> String -> Model
 isListed model value =
@@ -20,9 +20,20 @@ isListed model value =
         , found = List.member cropped model.hashes
     }
 
+updateFullName model value =
+    {
+        model
+        | fullName = value
+    }
+
+subscriptions : Model -> Sub Msg
+subscriptions _ =
+    receiveHash ReceiveHash
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
-        UpdateValue value ->
-            ( isListed model value, Cmd.none )
+        RequestHash value ->
+            ( updateFullName model value, requestHash value )
+        ReceiveHash hash ->
+            ( isListed model hash, Cmd.none )

--- a/src/View.elm
+++ b/src/View.elm
@@ -7,27 +7,26 @@ import Html.Events exposing (onInput)
 import Model exposing (Model)
 import Update exposing (Msg(..))
 
-
 view : Model -> Html Msg
 view model =
     let
         status : { title : String, text : String, class : String }
         status =
-            if String.length model.hash < 100 then
+            if String.length model.hash < 100 || model.fullName == "" then
                 { title = ""
-                , text = "Informe os 100 caracteres do hash do seu nome (pode colar tudo gue a gente descarta o que sobrar)."
+                , text = "Informe seu nome completo."
                 , class = "alert alert-secondary"
                 }
 
             else if model.found then
                 { title = "Cuidado"
-                , text = "Encontramos no dossiê hashes com os mesmos caracteres que você informou."
+                , text = "Encontramos no dossiê hashes a partir do seu nome completo informado."
                 , class = "alert alert-danger"
                 }
 
             else
                 { title = "Boa notícia"
-                , text = "Não existem hashes que iniciam com os mesmos caracteres do hash que você digitou."
+                , text = "Não existem hashes que iniciem com os mesmos caracteres do hash a partir do seu nome completo informado."
                 , class = "alert alert-success"
                 }
 
@@ -45,6 +44,6 @@ view model =
         []
         [ p
             []
-            [ input [ size 40, type_ "text", onInput UpdateValue ] [] ]
+            [ input [ size 40, type_ "text", onInput RequestHash ] [] ]
         , div [ class status.class ] message
         ]


### PR DESCRIPTION
Pessoal, eu particularmente acredito que ter uma solução integrada, sem a necessidade de criar um hash a partir de outro serviço, seja uma solução mais fácil para usuários leigos. Além disso, tentei tornar o projeto mais fácil para desenvolver localmente sem o PDF do dossiê (que foi o meu caso). Acredito que isso não tenha quebrado o projeto com o dossiê, mas vocês estarão numa melhor posição para verificar isso.

A biblioteca que estou usando para fazer o hash localmente é essa daqui:
https://www.npmjs.com/package/js-sha512

O código para a biblioteca está com verificação de integridade. Bom, pull-request é sempre uma proposta e estou aberto a demais considerações.

Excelente iniciativa! Abraço!